### PR TITLE
fix: handle multi-line imports

### DIFF
--- a/src/check-expression.test.ts
+++ b/src/check-expression.test.ts
@@ -83,4 +83,15 @@ describe('Check Expression', () => {
         expect(expression.test('foo bar\n import("my/file/path/test"); \n')).toBeTruthy();
       });
   });
+  describe('should detect imports and requires in various formats', () => {
+    it('should detect imports split across multiple lines', () => {
+      expect(expression.test("import MyComponent\n  from '@/components/test.vue';")).toBeTruthy();
+      expect(expression.test("const MyComponent =\n  require('@/components/test.vue');")).toBeTruthy();
+    });
+
+    it('should detect imports with varying whitespace around path', () => {
+      expect(expression.test("import MyComponent from   '@/components/test.vue' ;")).toBeTruthy();
+      expect(expression.test("const MyComponent = require(  '@/components/test.vue');")).toBeTruthy();
+    });
+  });
 });

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -5,7 +5,7 @@ import path from 'path';
 import glob from 'glob';
 
 export function getCheckExpression(file): string {
-  return `(import|require).*(?:[\'\"]\\b|\\/)${path.basename(file, path.extname(file))}(?:\\.(?:vue))?[\'\"][\\\);,]?[,;]?`;
+  return `(import|require)\\s*\\(?[\\s\\S]*?(?:[\'\"]\\b|\\/)${path.basename(file, path.extname(file))}(?:\\.(?:vue))?[\'\"][\\);,]?[,;]?`;
 }
 
 export default function (src, maxOpenFiles, ignore): void {


### PR DESCRIPTION
Fixes #27 

We have a few components with very long names and paths that have been broken on to two lines - the checker wrongly marks these as unused for some reason.